### PR TITLE
Improve/button list view

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "robb/Cartography" "1.0.1"
-github "krzyzanowskim/CryptoSwift" "0.6.3"
+github "krzyzanowskim/CryptoSwift" "0.6.4"
 github "vadymmarkov/Fashion" "2.0.0"
 github "hyperoslo/Hue" "2.0.0"
 github "zenangst/Tailor" "2.0.1"

--- a/Sources/iOS/ButtonListView.swift
+++ b/Sources/iOS/ButtonListView.swift
@@ -22,9 +22,9 @@ open class ButtonListView: UITableViewCell, SpotConfigurable {
   public weak var delegate: ButtonListViewDelegate? {
     didSet {
       selectionStyle = delegate == nil ? .default : .none
+      button.isUserInteractionEnabled = delegate != nil
     }
   }
-
 
   public var item: Item?
   public var preferredViewSize = CGSize(width: 0, height: 44)
@@ -40,7 +40,13 @@ open class ButtonListView: UITableViewCell, SpotConfigurable {
     }
   }
 
-  public lazy var button = UIButton()
+  public lazy var button: UIButton = {
+    let button = UIButton()
+    button.addTarget(self, action: #selector(buttonDidPress), for: .touchUpInside)
+
+    return button
+  }()
+
   public lazy var loadingIndicator = UIActivityIndicatorView()
 
   override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
@@ -70,12 +76,11 @@ open class ButtonListView: UITableViewCell, SpotConfigurable {
     styles = meta.styles
     button.setTitle(item.title, for: .normal)
     button.sizeToFit()
-    button.isUserInteractionEnabled = false
 
     if button.frame.size.width < 180 {
       button.frame.size.width = 180
     }
-    
+
     button.frame.size.height = preferredViewSize.height
     button.centerInSuperview()
 
@@ -94,5 +99,11 @@ open class ButtonListView: UITableViewCell, SpotConfigurable {
     super.layoutSubviews()
 
     button.layer.cornerRadius = button.frame.size.height / 2
+  }
+
+  // MARK: - Actions
+
+  func buttonDidPress() {
+    delegate?.buttonListViewDidPress(self)
   }
 }

--- a/Sources/iOS/ButtonListView.swift
+++ b/Sources/iOS/ButtonListView.swift
@@ -3,6 +3,10 @@ import Spots
 import Tailor
 import UIKit
 
+public protocol ButtonListViewDelegate: class {
+  func buttonListViewDidPress(_ view: ButtonListView)
+}
+
 open class ButtonListView: UITableViewCell, SpotConfigurable {
 
   struct Meta: Mappable {
@@ -14,6 +18,13 @@ open class ButtonListView: UITableViewCell, SpotConfigurable {
       self.enabled <- map.property("enabled")
     }
   }
+
+  public weak var delegate: ButtonListViewDelegate? {
+    didSet {
+      selectionStyle = delegate == nil ? .default : .none
+    }
+  }
+
 
   public var item: Item?
   public var preferredViewSize = CGSize(width: 0, height: 44)
@@ -64,6 +75,7 @@ open class ButtonListView: UITableViewCell, SpotConfigurable {
     if button.frame.size.width < 180 {
       button.frame.size.width = 180
     }
+    
     button.frame.size.height = preferredViewSize.height
     button.centerInSuperview()
 

--- a/Sources/iOS/ButtonListView.swift
+++ b/Sources/iOS/ButtonListView.swift
@@ -51,6 +51,8 @@ open class ButtonListView: UITableViewCell, SpotConfigurable {
 
   override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
+    selectionStyle = .default
+    button.isUserInteractionEnabled = false
     contentView.addSubview(button)
     button.addSubview(loadingIndicator)
     backgroundColor = UIColor.clear
@@ -62,11 +64,21 @@ open class ButtonListView: UITableViewCell, SpotConfigurable {
 
   override open func setHighlighted(_ highlighted: Bool, animated: Bool) {
     super.setHighlighted(false, animated: false)
+
+    guard delegate == nil else {
+      return
+    }
+
     button.isHighlighted = highlighted
   }
 
   override open func setSelected(_ selected: Bool, animated: Bool) {
     super.setSelected(false, animated: false)
+
+    guard delegate == nil else {
+      return
+    }
+
     button.isSelected = selected
   }
 

--- a/Sources/iOS/ButtonListView.swift
+++ b/Sources/iOS/ButtonListView.swift
@@ -45,10 +45,12 @@ open class ButtonListView: UITableViewCell, SpotConfigurable {
 
   override open func setHighlighted(_ highlighted: Bool, animated: Bool) {
     super.setHighlighted(false, animated: false)
+    button.isHighlighted = highlighted
   }
 
   override open func setSelected(_ selected: Bool, animated: Bool) {
     super.setSelected(false, animated: false)
+    button.isSelected = selected
   }
 
   public func configure(_ item: inout Item) {


### PR DESCRIPTION
@zenangst This PR introduces button list view delegate that we can set or skip. The problem here is that you still are able to tap on the cell outside the button, and spots delegate method will be invoked.
