### PR TITLE
Set styles before layout subviews

### DIFF
--- a/Sources/iOS/Classes/CoreListView.swift
+++ b/Sources/iOS/Classes/CoreListView.swift
@@ -85,6 +85,7 @@ open class CoreListView: ListSpotCell {
   override open func configure(_ item: inout Item) {
     let meta: Meta = item.metaInstance()
     disableSelected = meta.disableSelected
+    styles = item.styles
 
     self.item = item
 
@@ -113,7 +114,6 @@ open class CoreListView: ListSpotCell {
     }
 
     separatorView.frame.origin.y = item.size.height - 1
-    styles = item.styles
   }
 
   func layoutViews(item: inout Item) {


### PR DESCRIPTION
To layout subviews correctly, we need styles to be set before size calculations.