### PR TITLE
Remove .uppercased()

### DIFF
--- a/Sources/iOS/Classes/InputListView.swift
+++ b/Sources/iOS/Classes/InputListView.swift
@@ -146,7 +146,7 @@ open class InputFieldListView: UITableViewCell, SpotConfigurable {
     textField.frame.size.width = contentView.frame.size.width
     textField.text = item.text
 
-    let placeholderText = NSAttributedString(string: item.subtitle.uppercased(),
+    let placeholderText = NSAttributedString(string: item.subtitle,
                                              attributes: [
                                               NSForegroundColorAttributeName : infoLabel.textColor.alpha(0.5)
       ])


### PR DESCRIPTION
This PR removes the force upper casing on placeholder text in input list view.