### PR TITLE
Update touch

### DIFF
--- a/Example/MasqueradeDemo/MasqueradeDemo/Sources/Structs/MasqueradeConfigurator.swift
+++ b/Example/MasqueradeDemo/MasqueradeDemo/Sources/Structs/MasqueradeConfigurator.swift
@@ -15,6 +15,7 @@ struct MasqueradeConfigurator {
       Item(title: "HTML",   subtitle: listDescription, meta: ["kind" : "html"]),
       Item(title: "Info",   subtitle: listDescription, meta: ["kind" : "info"]),
       Item(title: "Input",  subtitle: listDescription, meta: ["kind" : "input"]),
+      Item(title: "Text",  subtitle: listDescription, meta: ["kind" : "text"]),
     ]
   }
 
@@ -31,7 +32,8 @@ struct MasqueradeConfigurator {
       "core" : CoreListView.self,
       "toggle" : ToggleListView.self,
       "info" : InfoListView.self,
-      "image" : ImageListView.self
+      "image" : ImageListView.self,
+      "text": TextListView.self
     ]
 
     gridItems = [

--- a/Example/MasqueradeDemo/Podfile.lock
+++ b/Example/MasqueradeDemo/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
-  - Brick (2.0.2):
+  - Brick (2.0.5):
     - Tailor (~> 2.0)
-  - Cache (2.1.1):
+  - Cache (2.2.1):
     - CryptoSwift
   - Cartography (1.0.1)
   - Compass (4.0.0)
   - CryptoSwift (0.6.0)
   - Fashion (2.0.0)
-  - Hue (2.0.0)
+  - Hue (2.0.1)
   - Imaginary (1.0.1):
     - Cache (~> 2.0)
   - Masquerade (0.1.0):
@@ -17,12 +17,12 @@ PODS:
     - Hue (~> 2.0)
     - Imaginary (~> 1.0)
     - Spots (~> 5.0)
-  - Spots (5.1.1):
+  - Spots (5.7.2):
     - Brick (~> 2.0)
     - Cache (~> 2.0)
     - CryptoSwift (= 0.6.0)
     - Tailor (~> 2.0)
-  - Tailor (2.0.1)
+  - Tailor (2.0.2)
 
 DEPENDENCIES:
   - Brick (~> 2.0)
@@ -38,17 +38,17 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  Brick: a7cf051da76f833e46281477d91b04cee63593f7
-  Cache: 525a292370641881d7e350f0d451fd276790243a
+  Brick: 08788c20c9b9aded5b9e89b8a8942c1b4933e91a
+  Cache: 5b2d2d68477bd9c5b8e539d673cc217ed1284814
   Cartography: c1460e99395b824d9d75360b0382faeb0b33dcd7
   Compass: b7802d133b95ffde747515f0e84ed8b5153c3d53
   CryptoSwift: 4a599b7241b8d3b857d6e2c28867d0bd5d1aae24
   Fashion: f5cd202dcd048edd35217349527ac446d0853cd7
-  Hue: 2b317616a04cc5d7cccdb024c88e6d143e2b9cf1
+  Hue: 354caec055fdc9d38b5ef33ca2e7224721843baf
   Imaginary: f37fb0dd81a5881cf7a8232d7854e8c5a689b054
   Masquerade: a6e8aea8f5dcaf699177a118589e431b56c88890
-  Spots: f75f3d6c67121aa55c82697d8d9e081860d4302c
-  Tailor: faa9ec5be402056be8ec67c0e461f00251d19191
+  Spots: 07f5917bd9a7a3a2184b1ae367c2843aa69f7296
+  Tailor: 6f03d033af361a7cf1f25627a1877c5b91a9618c
 
 PODFILE CHECKSUM: 17c1629fbdd6f19fa15f85e42e4950baff3f5dd5
 

--- a/Masquerade.xcodeproj/project.pbxproj
+++ b/Masquerade.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		BD9B54AC1DDAFC1200FCAE46 /* ListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9B54A21DDAFC1200FCAE46 /* ListView.swift */; };
 		BD9B54AD1DDAFC1200FCAE46 /* ToggleListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9B54A31DDAFC1200FCAE46 /* ToggleListView.swift */; };
 		BD9B54AE1DDAFC1200FCAE46 /* UIView+CenterInSuperview.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9B54A51DDAFC1200FCAE46 /* UIView+CenterInSuperview.swift */; };
+		D2A5A07E1E29023100350B6A /* TextLinkListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A5A07D1E29023100350B6A /* TextLinkListView.swift */; };
 		D5B2E8AA1C3A780C00C0327D /* Masquerade.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5B2E89F1C3A780C00C0327D /* Masquerade.framework */; };
 		D5C6294A1C3A7FAA007F7B7C /* Masquerade.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5C629401C3A7FAA007F7B7C /* Masquerade.framework */; };
 		D5C629851C3A893F007F7B7C /* Mac.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5C629841C3A893F007F7B7C /* Mac.swift */; };
@@ -65,6 +66,7 @@
 		BD9B54A21DDAFC1200FCAE46 /* ListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListView.swift; sourceTree = "<group>"; };
 		BD9B54A31DDAFC1200FCAE46 /* ToggleListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToggleListView.swift; sourceTree = "<group>"; };
 		BD9B54A51DDAFC1200FCAE46 /* UIView+CenterInSuperview.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+CenterInSuperview.swift"; sourceTree = "<group>"; };
+		D2A5A07D1E29023100350B6A /* TextLinkListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextLinkListView.swift; sourceTree = "<group>"; };
 		D500FD111C3AABED00782D78 /* Playground-iOS.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = "Playground-iOS.playground"; sourceTree = "<group>"; };
 		D500FD121C3AAC8E00782D78 /* Playground-Mac.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = "Playground-Mac.playground"; sourceTree = "<group>"; };
 		D5B2E89F1C3A780C00C0327D /* Masquerade.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Masquerade.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -151,6 +153,7 @@
 				BD9B54A11DDAFC1200FCAE46 /* InputListView.swift */,
 				BD9B54A21DDAFC1200FCAE46 /* ListView.swift */,
 				BD9B54A31DDAFC1200FCAE46 /* ToggleListView.swift */,
+				D2A5A07D1E29023100350B6A /* TextLinkListView.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -478,6 +481,7 @@
 				BD9B54A81DDAFC1200FCAE46 /* CoreListView.swift in Sources */,
 				BD9B54AB1DDAFC1200FCAE46 /* InputListView.swift in Sources */,
 				BD9B54AD1DDAFC1200FCAE46 /* ToggleListView.swift in Sources */,
+				D2A5A07E1E29023100350B6A /* TextLinkListView.swift in Sources */,
 				BD9B54A91DDAFC1200FCAE46 /* ImageListView.swift in Sources */,
 				BD9B54A71DDAFC1200FCAE46 /* CoreGridView.swift in Sources */,
 				BD9B54AC1DDAFC1200FCAE46 /* ListView.swift in Sources */,

--- a/Sources/iOS/Classes/ButtonListView.swift
+++ b/Sources/iOS/Classes/ButtonListView.swift
@@ -119,6 +119,12 @@ open class ButtonListView: UITableViewCell, SpotConfigurable {
     button.layer.cornerRadius = button.frame.size.height / 2
   }
 
+  open override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+    let result = super.point(inside: point, with: event)
+    let insidePoint = convert(point, to: button)
+    return result && button.point(inside: insidePoint, with: event)
+  }
+
   // MARK: - Actions
 
   func buttonDidPress() {

--- a/Sources/iOS/Classes/InputListView.swift
+++ b/Sources/iOS/Classes/InputListView.swift
@@ -199,4 +199,10 @@ open class InputFieldListView: UITableViewCell, SpotConfigurable {
     
     textField.layer.cornerRadius = textField.frame.size.height / 2
   }
+
+  open override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+    let result = super.point(inside: point, with: event)
+    let insidePoint = convert(point, to: textField)
+    return result && textField.point(inside: insidePoint, with: event)
+  }
 }

--- a/Sources/iOS/Classes/TextLinkListView.swift
+++ b/Sources/iOS/Classes/TextLinkListView.swift
@@ -1,0 +1,42 @@
+import UIKit
+import Brick
+import Fashion
+import Spots
+import Tailor
+
+open class TextListView: UITableViewCell, SpotConfigurable {
+
+  var item: Item?
+
+  public struct Meta: Mappable {
+    var styles: String = ""
+
+    public init(_ map: [String : Any]) {
+      self.styles <- map.property("styles")
+    }
+  }
+
+  public var preferredViewSize: CGSize = CGSize(width: 0, height: 44)
+
+  public func configure(_ item: inout Item) {
+    selectionStyle = .none
+    let meta: Meta = item.metaInstance()
+    styles = meta.styles
+
+    textLabel?.text = item.title
+    detailTextLabel?.text = item.subtitle
+    self.item = item
+  }
+
+  open override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+    let result = super.point(inside: point, with: event)
+
+    guard let textLabel = textLabel else {
+      return result
+    }
+
+    let insidePoint = convert(point, to: textLabel)
+    return result && textLabel.point(inside: insidePoint, with: event)
+  }
+}
+


### PR DESCRIPTION
- Add `TextListView` to show basic `textLabel` of `UITableViewCell`
- Can only touch on `button, textfield, label` inside the cell. This is ideal for forms as we don't want to touch outside of the `buttons, textfields, labels`